### PR TITLE
Add #cas and #cas_multi just like MemcachedStore

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -164,7 +164,6 @@ module ActiveSupport
                 result = c.multi { write key, new_entry, options }
               else
                 c.unwatch
-                result = false
               end
             end
           end
@@ -297,6 +296,7 @@ module ActiveSupport
                 end
               else
                 c.unwatch
+                return false
               end
             end
           end

--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -149,6 +149,45 @@ module ActiveSupport
         fetched
       end
 
+      # Performs a CAS operation (like MemcachedStore) using a watch,
+      # ensuring an optimistic lock on the given name
+      def cas(name, options = nil)
+        options = merged_options(options)
+        key = normalize_key(name, options)
+        result = false
+        instrument(:cas, name, options) do
+          with do |c|
+            c.watch(key) do
+              entry = read_entry(key, options)
+              if entry
+                new_entry = yield entry.value
+                result = c.multi { write key, new_entry, options }
+              else
+                result = false
+              end
+            end
+          end
+        end
+        result
+      end
+
+      # The memcache store implementation of this does this in one command.
+      # The tested behaviour is such that the command will lock per key - one
+      # conflcit should not fail the whole set, just the conflicted key.
+      def cas_multi(*names)
+        options = merged_options(names.extract_options!)
+        return false if names.empty?
+        instrument(:cas_multi, names, options) do
+          with do
+            current_entries = read_multi(*names, options)
+            new_entries = yield current_entries
+            return new_entries.map do |k, v|
+              set_unless_changed(k, v, current_entries[k], options)
+            end.any? || new_entries.empty?
+          end
+        end
+      end
+
       # Increment a key in the store.
       #
       # If the key doesn't exist it will be initialized on 0.
@@ -249,6 +288,19 @@ module ActiveSupport
           false
         end
 
+        def set_unless_changed(key, new_value, old_value, options)
+          with do |c|
+            c.watch(key) do
+              current_entry = read_entry(key, options)
+              if !old_value || current_entry.value == old_value
+                c.multi do
+                  write(key, new_value, options)
+                end
+              end
+            end
+          end
+        end
+
         def read_entry(key, options)
           entry = with { |c| c.get key, options }
           if entry
@@ -293,6 +345,8 @@ module ActiveSupport
         end
 
       private
+
+
 
         if ActiveSupport::VERSION::MAJOR < 5
           def normalize_key(*args)

--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -174,7 +174,7 @@ module ActiveSupport
 
       # The memcache store implementation of this does this in one command.
       # The tested behaviour is such that the command will lock per key - one
-      # conflcit should not fail the whole set, just the conflicted key.
+      # conflict should not fail the whole set, just the conflicted key.
       def cas_multi(*names)
         options = merged_options(names.extract_options!)
         return false if names.empty?

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -377,7 +377,7 @@ describe ActiveSupport::Cache::RedisStore do
       refute @store.cas('not_exist') { |_value| flunk }
     end
 
-    it "sets expirey" do
+    it "sets expiry" do
       @store.cas('foo', expires_in: 1.second) do |value|
         'bar'
       end
@@ -440,7 +440,7 @@ describe ActiveSupport::Cache::RedisStore do
       assert_equal({ 'foo' => 'baz', 'fud' => 'biz' }, @store.read_multi('foo', 'fud'))
     end
 
-    it 'sets expirey' do
+    it 'sets expiry' do
       @store.cas_multi('foo', expires_in: 1.second) do |_|
         { 'foo' => 'bar' }
       end

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -363,6 +363,94 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
+  describe 'cas' do
+    it 'performs a write' do
+      @store.write('foo', nil)
+      assert(@store.cas('foo') do |value|
+        assert_nil value
+        'bar'
+      end)
+      assert_equal 'bar', @store.read('foo')
+    end
+
+    it 'performs a cache miss' do
+      refute @store.cas('not_exist') { |_value| flunk }
+    end
+
+    it "sets expirey" do
+      @store.cas('foo', expires_in: 1.second) do |value|
+        'bar'
+      end
+      assert_equal 'bar', @store.read('foo')
+      sleep(1.1)
+      assert_nil @store.read('foo')
+    end
+  end
+
+  describe 'cas multi' do
+    it 'performs an update' do
+      @store.write('foo', 'bar')
+      @store.write('fud', 'biz')
+      assert_equal true, (@store.cas_multi('foo', 'fud') do |hash|
+        assert_equal({ 'foo' => 'bar', 'fud' => 'biz' }, hash)
+        { 'foo' => 'baz', 'fud' => 'buz' }
+      end)
+      assert_equal({ 'foo' => 'baz', 'fud' => 'buz' }, @store.read_multi('foo', 'fud'))
+    end
+
+    it 'empty set' do
+      refute @store.cas_multi { |_hash| flunk }
+    end
+
+    it 'partial conflict' do
+      @store.write('foo', 'bar')
+      @store.write('fud', 'biz')
+      result = @store.cas_multi('foo', 'fud') do |hash|
+        assert_equal({ 'foo' => 'bar', 'fud' => 'biz' }, hash)
+        @store.write('foo', 'bad')
+        { 'foo' => 'baz', 'fud' => 'buz' }
+      end
+      assert result
+      assert_equal({ 'foo' => 'bad', 'fud' => 'buz' }, @store.read_multi('foo', 'fud'))
+    end
+
+    it 'cache miss' do
+      assert(@store.cas_multi('not_exist') do |hash|
+        assert hash.empty?
+        {}
+      end)
+    end
+
+    it 'partial miss' do
+      @store.write('foo', 'baz')
+      assert(@store.cas_multi('foo', 'bar') do |hash|
+        assert_equal({ 'foo' => 'baz' }, hash)
+        {}
+      end)
+      assert_equal 'baz', @store.read('foo')
+    end
+
+    it 'partial update' do
+      @store.write('foo', 'bar')
+      @store.write('fud', 'biz')
+      assert(@store.cas_multi('foo', 'fud') do |hash|
+        assert_equal({ 'foo' => 'bar', 'fud' => 'biz' }, hash)
+        { 'foo' => 'baz' }
+      end)
+      assert_equal({ 'foo' => 'baz', 'fud' => 'biz' }, @store.read_multi('foo', 'fud'))
+    end
+
+    it 'sets expirey' do
+      @store.cas_multi('foo', expires_in: 1.second) do |_|
+        { 'foo' => 'bar' }
+      end
+      assert_equal 'bar', @store.read('foo')
+      sleep(1.1)
+      assert_nil @store.read('foo')
+    end
+  end
+
+
   describe "race_condition_ttl on fetch" do
     it "persist entry for longer than given ttl" do
       options = { force: true, expires_in: 1.second, race_condition_ttl: 2.seconds }


### PR DESCRIPTION
Adds #cas and #cas_multi support to the store.

This should allow redis to be used as a slot in replacement for memcache in https://github.com/Shopify/identity_cache

Redis doesn't natively support check and set but does allow for an approximation using watch (or a script). We're forced to use watch here because ActiveSupport::Cache::Entry serialises to the data store in a non deterministic way - so we must perform the equality check in ruby.